### PR TITLE
Update alpine Docker tag to v3.15.0

### DIFF
--- a/1.2-py3/Dockerfile
+++ b/1.2-py3/Dockerfile
@@ -1,7 +1,7 @@
 # Instructions on building libtorrent:
 #   https://github.com/arvidn/libtorrent/blob/RC_1_2/docs/building.rst
 
-FROM alpine:3.14.2@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
+FROM alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3
 
 ARG VERSION=1.2.[0-9]\\+
 

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -1,7 +1,7 @@
 # Instructions on building libtorrent:
 #   https://github.com/arvidn/libtorrent/blob/RC_2_0/docs/building.rst
 
-FROM alpine:3.14.2@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
+FROM alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3
 
 ARG VERSION=2.0.[0-9]\\+
 


### PR DESCRIPTION
This pull request aims to upgrade the docker-libtorrent images to use Alpine 3.15 instead of 3.14.

This is needed for the docker-qbittorrent image to be be built with qBittorrent 4.4.0 and Qt 6. I am planning to create a separate pull request once this image is built and the image hash is available.